### PR TITLE
make RemedyBG.Hook setting more robust

### DIFF
--- a/PythonScripts/RemedyBG/RemedyBG.py
+++ b/PythonScripts/RemedyBG/RemedyBG.py
@@ -95,7 +95,8 @@ class Options():
 		else:
 			self.build_before_debug = False
 
-		hook_calls = Editor.GetSetting("RemedyBG.Hook")
+		self.hook_calls = False
+		hook_calls = Editor.GetSetting("RemedyBG.Hook").strip().lower()
 		if hook_calls and hook_calls == 'true':
 			self.hook_calls = hook_calls
 


### PR DESCRIPTION
the previous version only worked if you had the setting defined to exactly `true`