### PR TITLE
Fix editor shortcuts when in command mode.

### DIFF
--- a/PythonScripts/Vim/Vim.py
+++ b/PythonScripts/Vim/Vim.py
@@ -539,7 +539,20 @@ def HandleCommandModeKey(key, shift, control, alt):
             key == "Up" or \
             key == "Down" or \
             key == "Left" or \
-            key == "Right"
+            key == "Right" or \
+            key == "F1" or \
+            key == "F2" or \
+            key == "F3" or \
+            key == "F4" or \
+            key == "F5" or \
+            key == "F6" or \
+            key == "F7" or \
+            key == "F8" or \
+            key == "F9" or \
+            key == "F10" or \
+            key == "F11" or \
+            key == "F12" or \
+            key.startswith("Mouse")
 
     if handled or pass_through:
         global g_RepeatCount


### PR DESCRIPTION
Pass through F-Keys and mouse buttons when in command mode. Allows user to build solution with F7 when in command mode for example.