### PR TITLE
Vim: Motion additions, improvements and bugfixes

### DIFF
--- a/PythonScripts/Vim/Vim.py
+++ b/PythonScripts/Vim/Vim.py
@@ -2029,6 +2029,12 @@ def HandleVisualModeChar(char):
     elif c == "G":
         MoveToEndOfFile();
 
+    elif c == "{":
+       MoveToPreviousEmptyLine()
+
+    elif c == "}":
+        MoveToNextEmptyLine()
+
     elif c == "g":
         return
 

--- a/PythonScripts/Vim/Vim.py
+++ b/PythonScripts/Vim/Vim.py
@@ -1424,7 +1424,7 @@ def HandleCommandModeChar(char):
         action = m.group(2)
         if pos := SelectAroundBlock(action, count):
             N10X.Editor.PushUndoGroup()
-            N10X.Editor.ExecuteCommand("")
+            N10X.Editor.ExecuteCommand("Cut")
             EnterInsertMode()
             N10X.Editor.PopUndoGroup()
     

--- a/PythonScripts/Vim/Vim.py
+++ b/PythonScripts/Vim/Vim.py
@@ -2014,6 +2014,22 @@ def HandleVisualModeChar(char):
         SetCursorPos(start[0], start[1])
         EnterCommandMode()
 
+    elif c == "p":
+        N10X.Editor.PushUndoGroup()
+        for i in range(repeat_count):
+            clipboard_value = GetClipboardValue()
+            if clipboard_value and clipboard_value[-1:] == "\n":
+                SendKey("Enter")
+                start = N10X.Editor.GetCursorPos()
+                N10X.Editor.InsertText(clipboard_value)
+                x, y = GetNextNonWhitespaceCharPos(start[0], start[1], False)
+                SetCursorPos(x, y)
+            else:
+                N10X.Editor.ExecuteCommand("Paste")
+                MoveCursorPos(x_delta=-1, max_offset=0)
+        N10X.Editor.PopUndoGroup()
+        EnterCommandMode()
+
     elif c == "c":
         start, _ = SubmitVisualModeSelection()
         N10X.Editor.ExecuteCommand("Cut")

--- a/PythonScripts/Vim/Vim.py
+++ b/PythonScripts/Vim/Vim.py
@@ -639,18 +639,20 @@ def MoveToPreviousEmptyLine():
       text = N10X.Editor.GetLine(y)
       if text.isspace():
         N10X.Editor.SetCursorPos((0, y))
-        break
+        return
+    N10X.Editor.SetCursorPos((0, 0))
 
 #------------------------------------------------------------------------
 def MoveToNextEmptyLine():
     line_count = N10X.Editor.GetLineCount()
     x, y = N10X.Editor.GetCursorPos()
-    while y < line_count:
+    while y < line_count - 1:
       text = N10X.Editor.GetLine(y + 1)
       if not text or text.isspace():
         N10X.Editor.SetCursorPos((0, y + 1))
-        break
+        return
       y = y + 1
+    N10X.Editor.SetCursorPos((GetLineLength(y) - 1, line_count))
       
 #------------------------------------------------------------------------
 def NormalizeBlockChar(c):

--- a/PythonScripts/Vim/Vim.py
+++ b/PythonScripts/Vim/Vim.py
@@ -1573,7 +1573,7 @@ def HandleCommandModeChar(char):
 
     # Copying
 
-    elif c == "yy":
+    elif c == "yy" or c == "Y":
         x, y = N10X.Editor.GetCursorPos()
         end_y = min(y + repeat_count - 1, GetMaxY())
         SetLineSelection(y, end_y)

--- a/PythonScripts/Vim/Vim.py
+++ b/PythonScripts/Vim/Vim.py
@@ -514,7 +514,7 @@ def GetNextCharPos(x, y, wrap=True):
 
 #------------------------------------------------------------------------
 def AtEndOfFile(x, y):
-    return y >= GetMaxY() and x >= GetLineLength(GetMaxY())
+    return y > GetMaxY() or (y == GetMaxY() and x >= GetLineLength(GetMaxY()))
 
 #------------------------------------------------------------------------
 def GetNextNonWhitespaceCharPos(x, y, wrap=True):
@@ -717,7 +717,6 @@ def FindEnclosingBlockEndPos(c, start, count=1):
 
     while not AtEndOfFile(x, y):
         line = GetLine(y)
-
         if open_char not in line and closed_char not in line:
             x, y = 0, y + 1
             continue
@@ -779,6 +778,9 @@ def FindSameLineBlockStartPos(c, start):
     
     x, y = start
     line = GetLine(y)
+
+    if open_char not in line:
+        return None
 
     while x < len(line):
         if line[x] == closed_char:
@@ -2003,7 +2005,7 @@ def HandleVisualModeChar(char):
         else:
             g_Mode = Mode.VISUAL_LINE
 
-    elif c == "y":
+    elif c == "y" or c == "Y":
         start, _ = SubmitVisualModeSelection()
         N10X.Editor.ExecuteCommand("Copy")
         N10X.Editor.ClearSelection()


### PR DESCRIPTION
Features:
- Implement `{` and `}` motions to Visual mode
- Add `Y` (alias for `yy`)
- Add `p`aste to Visual mode

Bugfixes:
- Fixed `ci"` deleting empty strings
- Fixed quote text-object motion only working for double quoted strings
- Fixed one-off error when a selection is added to the current one
- Fixed same-line text-object motions when there are two blocks
- Fixed AtEndOfFile logic, which caused FindEnclosingBlockEndPos to loop forever
- `vi_` and `va_` no longer adds to your selection when using block motions
- `{` and `}` will jump to the start or end of a file if a non-empty line can't be found