### PR TITLE
Vim: Fix same-line text-object motions, fix `ci_` inserting new lines in edge cases

### DIFF
--- a/PythonScripts/Vim/Vim.py
+++ b/PythonScripts/Vim/Vim.py
@@ -1468,8 +1468,10 @@ def HandleCommandModeChar(char):
         if sel := SelectOrMoveInsideBlock(action, count, True):
             start, end = sel
             N10X.Editor.PushUndoGroup()
+            insert_line = GetLine(start[1] - 1)[-3:-1] == action + "\r\n"
             N10X.Editor.ExecuteCommand("Cut")
-            if end[1] - start[1] > 0:
+            if insert_line:
+                pass
                 N10X.Editor.ExecuteCommand("InsertLine")
             EnterInsertMode()
             N10X.Editor.PopUndoGroup()

--- a/PythonScripts/Vim/Vim.py
+++ b/PythonScripts/Vim/Vim.py
@@ -1471,7 +1471,6 @@ def HandleCommandModeChar(char):
             insert_line = GetLine(start[1] - 1)[-3:-1] == action + "\r\n"
             N10X.Editor.ExecuteCommand("Cut")
             if insert_line:
-                pass
                 N10X.Editor.ExecuteCommand("InsertLine")
             EnterInsertMode()
             N10X.Editor.PopUndoGroup()

--- a/PythonScripts/Vim/Vim.py
+++ b/PythonScripts/Vim/Vim.py
@@ -784,14 +784,14 @@ def FindSameLineBlockStartPos(c, start):
     if open_char not in line:
         return None
 
-    if line.strip() != open_char:
-        return None
-
     while x < len(line):
-        if line[x] == closed_char:
-            return None
-        elif line[x] == open_char:
-            return x
+        if not IsWhitespaceChar(line[x]):
+            if line[x] == open_char:
+                return x
+            elif line[x] == closed_char:
+                return None
+            else:
+                return None
         x += 1
     return None
     

--- a/PythonScripts/Vim/Vim.py
+++ b/PythonScripts/Vim/Vim.py
@@ -784,6 +784,9 @@ def FindSameLineBlockStartPos(c, start):
     if open_char not in line:
         return None
 
+    if line.strip() != open_char:
+        return None
+
     while x < len(line):
         if line[x] == closed_char:
             return None


### PR DESCRIPTION
- Fixed same-line text-object motion being prioritized when there was non-whitespace characters preceding it
- Fixed `ci_` inserting a line above the entire block when the block start had whitespace