### PR TITLE
RemedyBG: typo on 10x's installation directory

### DIFF
--- a/PythonScripts/RemedyBG/README.md
+++ b/PythonScripts/RemedyBG/README.md
@@ -17,10 +17,10 @@ Version: 0.1.0
 To install these modules in 10x's python use the pip command with python3 and set  
 the target to be 10x's installation directory:
 
-> python3 -m pip install --target="C:\Program Files\PureDevSoftware\10x"
+> python3 -m pip install --target="C:\Program Files\PureDevSoftware\10x\Lib\site-packages"
 > requests
 
-> python3 -m pip install --target="C:\Program Files\PureDevSoftware\10x"
+> python3 -m pip install --target="C:\Program Files\PureDevSoftware\10x\Lib\site-packages"
 > BeautifulSoup4
 
 **You can get the Portal Token from the itch.io download page url for RemedyBG:**  


### PR DESCRIPTION
Documentation :
```
python3 -m pip install --target="C:\Program Files\PureDevSoftware\10x" requests
python3 -m pip install --target="C:\Program Files\PureDevSoftware\10x" BeautifulSoup4
```
The target is `C:\Program Files\PureDevSoftware\10x` but the documentation indicates :
```
Adding Packages
To add packages to the 10x python installation copy the package file or folder to the site-packages folder in the 10x install folder and restart 10x.
C:\Program Files\PureDevSoftware\10x\Lib\site-packages\
```


So i replaced `C:\Program Files\PureDevSoftware\10x` by `C:\Program Files\PureDevSoftware\10x\Lib\site-packages\`.