### PR TITLE
Fix Vim.py clipboard error handling

### DIFF
--- a/PythonScripts/Vim/Vim.py
+++ b/PythonScripts/Vim/Vim.py
@@ -323,9 +323,9 @@ def AddNewlineToClipboard():
             win32clipboard.CloseClipboard()
             break
         except Exception as ex:
-            if err.winerror == 5:  # access denied
+            if ex.winerror == 5:  # access denied
                 time.sleep( 0.01 )
-            elif err.winerror == 1418:  # doesn't have board open
+            elif ex.winerror == 1418:  # doesn't have board open
                 pass
             else:
                 pass


### PR DESCRIPTION
Exception variable is named ex, not err

As a result of this issue, my 10x editor became effectively stuck in INSERT mode but with a block cursor. No Escape or Control C sequence could go into NORMAL mode.

I don't have a good idea of what caused the issue or error, except that I think an auto-complete window of some kind had popped up at the time.

10x error output:
```
[python] Traceback (most recent call last):
[python]   File "C:/Users/gavin/AppData/Roaming/10x/PythonScripts/Vim.py", line 317, in AddNewlineToClipboard
[python]     win32clipboard.OpenClipboard()
[python] pywintypes.error: (5, 'OpenClipboard', 'Access is denied.')
[python] 
During handling of the above exception, another exception occurred:

[python] Traceback (most recent call last):
[python]   File "C:/Users/gavin/AppData/Roaming/10x/PythonScripts/Vim.py", line 2889, in OnInterceptCharKey
[python]     HandleCommandModeChar(c)
[python]   File "C:/Users/gavin/AppData/Roaming/10x/PythonScripts/Vim.py", line 1794, in HandleCommandModeChar
[python]     AddNewlineToClipboard()
[python]   File "C:/Users/gavin/AppData/Roaming/10x/PythonScripts/Vim.py", line 326, in AddNewlineToClipboard
[python]     if err.winerror == 5:  # access denied
[python] NameError: name 'err' is not defined
Error: Callback function failed. Removing callback: <function OnInterceptCharKey at 0x0000016EABF5E050>
```