### PR TITLE
Add a port of the Solarized Light color scheme

### DIFF
--- a/ColorSchemes/SolarizedLight.10x_settings
+++ b/ColorSchemes/SolarizedLight.10x_settings
@@ -1,0 +1,386 @@
+# Format: <SettingName>: <Settingvalue>
+# Setting name must appear at start of line and there must be whitespace after the colon.
+
+# The main UI color
+UI.UI:                                            238, 232, 213
+
+# Text color for the main UI
+UI.UI Text:                                       7, 54, 66
+
+# Color of the main drop down menu
+UI.Menu:                                          default
+
+# Color of menu items as the mouse moves over
+UI.Menu (highlighted):                            default
+
+# Color of menu items that are selected (showing sub menus)
+UI.Menu (selected):                               default
+
+# App border when app is active
+UI.App Border (active):                           default
+
+# App border when app is inactive
+UI.App Border (inactive):                         default
+
+# Color of the tab for the currently active panel
+UI.Panels.Active Tab:                             88, 110, 117
+
+# Text color for active tabs
+UI.Panels.Active Tab Text:                        238, 232, 213
+
+# Text color for inactive tabs
+UI.Panels.Inactive Tab Text:                      88, 110, 117
+
+# Color of tabs for inactive panels
+UI.Panels.Inactive Tab:                           190, 190, 190
+
+# Color of the scrollbar background
+UI.Panels.Scrollbar Background:                   default
+
+# Color of the scrollbar bar
+UI.Panels.Scrollbar Bar:                          default
+
+# Color of the map-scrollbar bar
+UI.Panels.MapScrollbar Bar:                       default
+
+# Color of the scrollbar bar when the mouse is hovering over
+UI.Panels.Scrollbar Bar (hover):                  default
+
+# Color of the scrollbar bar when being dragged
+UI.Panels.Scrollbar Bar (drag):                   default
+
+# Default text color for all text editor windows
+Editor.Text:                                      101, 123, 131
+
+# Default background color for all text editor windows
+Editor.Background:                                253, 246, 227
+
+# Text Editor cursor (caret) color
+Editor.Cursor:                                    default
+
+# Background color for the current line
+Editor.Current Line:                              238,232,227
+
+# Background color of selected text
+Editor.Selection Back:                            131, 148, 186
+
+# Foreground color of selected text. Use 'default' for no foreground color.
+Editor.Selection Fore:                            255, 255, 255
+
+# Text background color for text highlighted by the Find tool
+Editor.Find.Text Highlight:                       220, 210, 100
+
+# Text background color for text highlighted when renaming a symbol
+Editor.Rename Symbol Back:                        255, 153, 0
+
+# Text foreground color for text highlighted when renaming a symbol
+Editor.Rename Symbol Fore:                        0, 0, 0
+
+# Text editor text color
+Language.Text:                                    default
+
+# Text editor background color
+Language.Background:                              default
+
+# Number
+Language.Number:                                  42, 161, 152
+
+# C++ Keyword
+Language.Keyword:                                 133, 153, 0
+
+# Preprocessor
+Language.Preprocessor:                            203, 75, 22
+
+# Comment
+Language.Comment:                                 147, 161, 161
+
+# {}
+Language.Brace:                                   default
+
+# ()
+Language.Bracket:                                 default
+
+# []
+Language.SquareBracket:                           default
+
+# ;
+Language.SemiColon:                               211, 54, 130
+
+# C++ Operator
+Language.Operator:                                211, 54, 130
+
+# String
+Language.String:                                  42, 161, 152
+
+# ,
+Language.Comma:                                   211, 54, 130
+
+# Class
+Language.Class:                                   181, 137, 0
+
+# Function
+Language.Function:                                108, 113, 196
+
+# Member Function
+Language.MemberFunction:                          108, 113, 196
+
+# Enum
+Language.Enum:                                    181, 137, 0
+
+# Enum Value
+Language.Enum Value:                              181, 137, 0
+
+# Variable
+Language.Variable:                                default
+
+# Member Variable
+Language.MemberVariable:                          38, 139, 210
+
+# Namespace
+Language.Namespace:                               181, 137, 0
+
+# Typedef
+Language.Typedef:                                 181, 137, 0
+
+# C++ Type
+Language.Type:                                    181, 137, 0
+
+# Line number colors
+Editor.Line Numbers:                              default
+
+# Margin color
+Editor.Margin:                                    default
+
+# Build error
+Build.BuildError:                                 255, 0, 0
+
+# Workspace tree node text
+TreeNodeText:                                     50, 50, 50
+
+# Workspace active tree node text
+TreeNodeTextActive:                               0, 0, 0
+
+# Build warning
+Build.BuildWarning:                               150, 100, 50
+
+# Current symbol highlight color
+Editor.SymbolHighlight:                           default
+
+# Bookmark
+Editor.Bookmark:                                  default
+
+# 10x output error
+UI.10xOutputError:                                255, 120, 120
+
+# 10x output warning
+UI.10xOutputWarning:                              150, 100, 50
+
+# Color of the matched text
+Search.TextMatch:                                 162, 209, 211
+
+# color of the highlighted line in the Search panel
+Search.HighlightLineColour:                       206, 233, 234
+
+# Highlight the matching brace/bracket color
+Editor.Find.Brace/Bracket Highlight:              default
+
+# Highlight the matching start/end bracket color
+Editor.Find.Bracket Highlight:                    default
+
+# Breakpoint
+Editor.Breakpoint:                                255, 0, 0
+
+# Whitespace
+Editor.Whitespace:                                default
+
+# Indent line
+Editor.IndentLine:                                default
+
+# Highlight for search results list
+UI.SearchHighlight:                               255, 220, 140
+
+# Autocomplete hover box background color
+Editor.AutocompleteBackColour:                    default
+
+# Autocomplete hover box foreground color
+Editor.AutocompleteForeColour:                    default
+
+# Autocomplete hover box border color
+Editor.AutocompleteBorderColour:                  default
+
+# Hover box background color
+Editor.HoverBoxBackColour:                        default
+
+# Hover box foreground color
+Editor.HoverBoxForeColour:                        default
+
+# Hover box border color
+Editor.HoverBoxBorderColour:                      default
+
+# Defined out code
+Language.DefinedOut:                              140, 140, 140
+
+# Edit box text selections, button toggle colors
+UI.UI Highlight:                                  0, 100, 200
+
+# Vertical rulers
+Editor.VerticalRulers:                            default
+
+# Selected items (in list boxes etc)
+UI.UI Selected Item:                              160, 200, 240
+
+# Edit box text selections
+UI.UI Selected Text:                              160, 200, 240
+
+# 10x logo background
+UI.LogoBack:                                      160, 160, 164
+
+# 10x logo foreground
+UI.LogoFore:                                      255, 255, 255
+
+# Workspace tree node
+UI.WorkspaceTreeNode:                             180, 180, 240
+
+# Active workspace tree node
+UI.ActiveWorkspaceTreeNode:                       130, 130, 255
+
+# Workspace tree node border
+UI.WorkspaceTreeNodeBorder:                       80, 80, 80
+
+# Active workspace tree node border
+UI.ActiveWorkspaceTreeNodeBorder:                 0, 0, 0
+
+# Source file tree node
+UI.SourceFileTreeNode:                            120, 170, 240
+
+# Header file tree node
+UI.HeaderFileTreeNode:                            80, 120, 170
+
+# Misc file tree node
+UI.MiscFileTreeNode:                              255, 255, 255
+
+# Misc file tree node
+UI.FolderTreeNode:                                255, 219, 79
+
+# Name of a setting in a 10x settings file
+10x.Setting.Name:                                 60, 80, 210
+
+# true setting valuea in a 10x settings file
+10x.Setting.True:                                 0, 0, 0
+
+# false setting valuea in a 10x settings file
+10x.Setting.False:                                255, 0, 0
+
+# name of an html element
+Html.ElementName:                                 23, 45, 255
+
+# name of an html attribute
+Html.AttributeName:                               30, 121, 247
+
+# html string
+Html.String:                                      62, 155, 174
+
+# html operator
+Html.Operator:                                    90, 90, 90
+
+# Document Heading
+Language.Heading:                                 255, 128, 0
+
+# Bold text
+Language.Bold:                                    0, 0, 120
+
+# Italic text
+Language.Italic:                                  0, 100, 200
+
+# Document block quote
+Language.Blockquote:                              100, 120, 140
+
+# Document list item
+Language.ListItem:                                0, 200, 150
+
+# Url Link
+Language.Link:                                    100, 100, 255
+
+# Document code block
+Language.CodeBlock:                               90, 140, 160
+
+# Custom color defined in all color schemes that can be used in the syntax highlighting rules
+Language.Custom1:                                 90, 190, 220
+
+# Custom color defined in all color schemes that can be used in the syntax highlighting rules
+Language.Custom2:                                 255, 140, 0
+
+# Custom color defined in all color schemes that can be used in the syntax highlighting rules
+Language.Custom3:                                 160, 160, 50
+
+# Custom color defined in all color schemes that can be used in the syntax highlighting rules
+Language.Custom4:                                 91, 200, 71
+
+# Custom color defined in all color schemes that can be used in the syntax highlighting rules
+Language.Custom5:                                 94, 115, 255
+
+# Custom color defined in all color schemes that can be used in the syntax highlighting rules
+Language.Custom6:                                 214, 97, 216
+
+# Custom color defined in all color schemes that can be used in the syntax highlighting rules
+Language.Custom7:                                 96, 153, 214
+
+# Custom color defined in all color schemes that can be used in the syntax highlighting rules
+Language.Custom8:                                 122, 180, 5
+
+# Custom color defined in all color schemes that can be used in the syntax highlighting rules
+Language.Custom9:                                 124, 157, 189
+
+# Custom color defined in all color schemes that can be used in the syntax highlighting rules
+Language.Custom10:                                214, 113, 113
+
+# 10x settings file keywords
+10x.Setting.Keyword:                              173, 235, 150
+
+# Line endings
+Editor.LineEndings:                               default
+
+# Color of the selected line in search results
+UI.SelectedSearchResultLine:                      155, 185, 222
+
+# Collapse/expand buttons
+Editor.CollapseExpandButton:                      0, 0, 0
+
+# Color of the find match results in the scroll bar
+UI.ScrollBarFindMatchHighlight:                   255, 0, 0
+
+# Color of the current word match results in the scroll bar
+UI.ScrollBarWordMatchHighlight:                   default
+
+# Brace/bracket colour at depth 1
+Editor.BraceDepth1:                               0, 180, 180
+
+
+# Brace/bracket colour at depth 2
+Editor.BraceDepth2:                               241, 130, 14
+
+
+# Brace/bracket colour at depth 3
+Editor.BraceDepth3:                               246, 62, 11
+
+
+# Brace/bracket colour at depth 4
+Editor.BraceDepth4:                               115, 167, 84
+
+
+# Brace/bracket colour at depth 5
+Editor.BraceDepth5:                               218, 115, 246
+
+
+# Brace/bracket colour at depth 6
+Editor.BraceDepth6:                               92, 119, 254
+
+
+# Debugger step line
+Editor.DebuggerStepLine:                          default
+
+
+# Status bar line colour while debugging
+Editor.DebuggingStatusBarColour:                  default
+
+


### PR DESCRIPTION
Hi,

I wrote a port of the [Solarized Light](https://ethanschoonover.com/solarized/) color scheme using the preexisting color scheme "Light" as a base.
Although I followed the official colors, I did make some personal choices for things that weren't mentioned in their website, like the member/non member functions and variables.

I've been using it full time for about a week and I think it'll be nice to have it included as part of the official color schemes, since a lot of other editors/IDEs include it (or some variation of it) by default.

Here's a small preview:

![Screenshot 2024-06-07 153244](https://github.com/slynch8/10x/assets/13398586/cf30aed5-1b6f-4b57-9c80-dbcaa7f30af8)

Thanks.