### PR TITLE
New commandline mode WIP

### DIFF
--- a/PythonScripts/Vim/Vim.py
+++ b/PythonScripts/Vim/Vim.py
@@ -410,7 +410,9 @@ def EnterCommandMode():
     global g_SingleReplace
     global g_MultiReplace
     global g_PaneSwap
+    global g_Error
 
+    g_Error = ""
     g_PaneSwap = False
     ClearCommandStr(False)
 
@@ -431,9 +433,10 @@ def EnterCommandMode():
 
 #------------------------------------------------------------------------
 def EnterCommandlineMode(char):
-    global g_Mode, g_CommandlineText, g_CommandlineTextCursorPos
+    global g_Mode, g_Error, g_CommandlineText, g_CommandlineTextCursorPos
 
     g_Mode = Mode.COMMANDLINE
+    g_Error = ""
     g_CommandlineText = char 
     g_CommandlineTextCursorPos = 1
     UpdateCursorMode()
@@ -442,6 +445,7 @@ def EnterCommandlineMode(char):
 def EnterVisualMode(mode):
     global g_Mode
     global g_VisualModeStartPos
+
     if g_Mode != mode:
         g_Mode = mode
         g_VisualModeStartPos = N10X.Editor.GetCursorPos()
@@ -451,7 +455,6 @@ def EnterVisualMode(mode):
 #------------------------------------------------------------------------
 def EnterSuspendedMode():
     global g_Mode
-    g_Mode = Mode.SUSPENDED
     UpdateCursorMode()
 
 #------------------------------------------------------------------------
@@ -2523,10 +2526,11 @@ def HandleCommandlineModeKey(key: Key):
     elif key == Key("Enter") and is_command:
         # TODO: Strip spaces between ':' and next alphanumeric character from g_CommandlineText
         valid_command = SubmitCommandline(g_CommandlineText)
+        EnterCommandMode()
         if not valid_command:
+            # Set g_Error after EnterCommandMode as this clears it
             g_Error = "Error: Not an editor command: " + g_CommandlineText[1:]
         g_CommandlineText = ""
-        EnterCommandMode()
 
     # Delete operations
 


### PR DESCRIPTION
New commandline mode that uses the status text bar to emulate vim commandline-mode in a more natural vim way, rather than using 10x command panel. \

This is for commands that start with `:` and searching with `/`. However searching is currently unsupported as we're awaiting some new 10x commands to support it. 

Experimental and open for feedback. It's disabled by default and can be enabled by setting VimEnableCommandlineMode: true in settings and restarting 10x.

Known missing features:
* Add support for command history
* Support searching 
* Support substitution

Demonstration:

![10xVimCommandline](https://github.com/user-attachments/assets/0fa8de3d-d292-44c2-8c95-97fff4fda49f)

