### PR TITLE
Remove semicolon from header prototype

### DIFF
--- a/PythonScripts/SignatureCreator/SignatureCreator.py
+++ b/PythonScripts/SignatureCreator/SignatureCreator.py
@@ -14,6 +14,7 @@ def Define():
 	BeforeVariables = BeforeVariables.replace("static", "")
 
 	CurrentLineText = BeforeVariables + "(" + CurrentLineText.split("(")[1]
+	CurrentLineText = CurrentLineText.replace(';', '')
 
 
 	SplitLine = CurrentLineText.split()


### PR DESCRIPTION
Prior to this commit, if you have ```void Prototype();``` in the header and then exercise the ```Define()``` function, you would end up with ```void Classname::Prototype();{}``` in your cpp file. This change prevents that.