### PR TITLE
""H"/"M"/"L" and "zt"/"zz"/"zb" added to visual mode

### DIFF
--- a/PythonScripts/Vim/Vim.py
+++ b/PythonScripts/Vim/Vim.py
@@ -3460,6 +3460,42 @@ def HandleVisualModeChar(char):
         EnterCommandMode()
         should_save = True
 
+    elif c == "z":
+        return
+
+    elif c == "zt":
+        # Apply offset so we don't set the current line as the first visible line but the one just after.
+        # This is so we can smooth scroll up using k after zt because 10x prevents the cursor being
+        # on the first visible line.
+        offset = 1
+        N10X.Editor.SetScrollLine(max(0, N10X.Editor.GetCursorPos()[1] - offset))
+
+    elif c == "zz":
+        N10X.Editor.CenterViewAtLinePos(N10X.Editor.GetCursorPos()[1])
+
+    elif c == "zb":
+        # Apply offset so we don't set the current line as last visible line but the one just before.
+        # This is so we can smooth scroll down using j after zb because 10x prevents the cursor being
+        # on the last visible line.
+        offset = 1
+        # Subtract 1 because ScrollLine is 0 indexed
+        bottom = N10X.Editor.GetScrollLine() + N10X.Editor.GetVisibleLineCount() - 1 - offset
+        scroll_delta = bottom - N10X.Editor.GetCursorPos()[1]
+        N10X.Editor.SetScrollLine(max(0, N10X.Editor.GetScrollLine() - scroll_delta))
+
+    elif c == "H":
+        scroll_line = N10X.Editor.GetScrollLine()
+        SetCursorPos(y=scroll_line+1)
+
+    elif c == "L":
+        scroll_line = N10X.Editor.GetScrollLine()
+        visible_line_count = N10X.Editor.GetVisibleLineCount()
+        SetCursorPos(y=scroll_line + visible_line_count-2)
+
+    elif c == "M":
+        scroll_line = N10X.Editor.GetScrollLine()
+        visible_line_count = N10X.Editor.GetVisibleLineCount()
+        SetCursorPos(y=scroll_line + int(visible_line_count / 2))
     else:
         print("[vim] Unknown command!")
     


### PR DESCRIPTION
@SimpsonGSD
Easy fix.