### PR TITLE
Added missing " to args when starting up Remedy

### DIFF
--- a/PythonScripts/RemedyBG/RemedyBG.py
+++ b/PythonScripts/RemedyBG/RemedyBG.py
@@ -762,7 +762,7 @@ class RDBG_Session:
                     Editor.ShowMessageBox(RDBG_TITLE, 'Debugger executable does not exist: "{}" (cwd: "{}")'.format(debug_cmd, debug_cwd))
                     return False
 
-                args = gOptions.executable + ' --servername ' + self.name + ' "' + debug_cmd + '"' + (' ' if debug_args!='' else '') + debug_args
+                args = gOptions.executable + ' --servername "' + self.name + '" "' + debug_cmd + '"' + (' ' if debug_args!='' else '') + debug_args
 
             self.process = subprocess.Popen(args, cwd=debug_cwd)
             time.sleep(0.1)


### PR DESCRIPTION
Workspaces (I think - untested) and .sln files can have spaces in their names and still be valid - this just ensures that the Remedy server has the correct named pipe when starting