### PR TITLE
Add .svelte extension to syntax highlighting settings

### DIFF
--- a/SyntaxHighlighting/html.10x_syntax
+++ b/SyntaxHighlighting/html.10x_syntax
@@ -12,7 +12,7 @@
 #----------------------------------------------
 # settings
 
-Extensions:					.html,.htm
+Extensions:					.html,.htm,.svelte
 
 BlockCommentStart:			<!--
 


### PR DESCRIPTION
Svelte files are .html