### PR TITLE
Fixed some annoying vim bugs

### DIFF
--- a/PythonScripts/Vim/Vim.py
+++ b/PythonScripts/Vim/Vim.py
@@ -3513,6 +3513,7 @@ def HandleVisualModeChar(char):
         should_save = True
 
     elif c == "p":
+        start, _ = SubmitVisualModeSelection()
         N10X.Editor.PushUndoGroup()
         for i in range(repeat_count):
             clipboard_value = GetClipboardValue()
@@ -3526,7 +3527,6 @@ def HandleVisualModeChar(char):
                 N10X.Editor.ExecuteCommand("Paste")
                 MoveCursorPos(x_delta=-1, max_offset=0)
         N10X.Editor.PopUndoGroup()
-        EnterCommandMode()
         should_save = True
 
     elif c == "c":


### PR DESCRIPTION
Fixed double paste when entering visual mode and pasting with 1 character highlighted
Fixed cut around block not cutting, e.g. ca{ ca(, etc.
Fixed off by 1 error when doing s/foo/bar/2 if this was ran on the last 2 lines of the file.
Fixed incorrect handling of non-text clipboard when pasting into commandline mode that would crash the script.