### PR TITLE
Add PostSave hook to ClangFormat

### DIFF
--- a/PythonScripts/ClangFormat/ClangFormat.py
+++ b/PythonScripts/ClangFormat/ClangFormat.py
@@ -3,6 +3,8 @@
 #     - "ClangFormat.Path": Path to clang-format executable, default: "clang-format.exe"
 #     - "ClangFormat.Style": One of 'LLVM', 'GNU', 'Google', 'Chromium', 'Microsoft', 'Mozilla', 'WebKit' values
 #                            Or 'file' if you are providing .clang-format file in your project
+#     - "ClangFormat.OnSave": 'true' or 'false'. When true, clang-format is called on save
+#     - "ClangFormat.OnSaveExtensions": comma-separated list of extensions allowed to auto-format on save
 #
 import subprocess
 import os
@@ -50,7 +52,8 @@ def _ClangFormat(file, line_range=None):
 
         process = subprocess.Popen(command,
                             shell=True, stdin=None, stdout=None, stderr=subprocess.PIPE,
-                            close_fds=True, cwd=cwd)
+                            close_fds=True, cwd=cwd,
+                            creationflags=subprocess.CREATE_NO_WINDOW)
         _, stderr = process.communicate()
         if process.returncode != 0:
             print('[ClangFormat]: clang-format failed (exit code ' + str(process.returncode) + ')')
@@ -72,3 +75,26 @@ def ClangFormatSelection():
 def ClangFormatFile():
     N10X.Editor.SaveFile()
     _ClangFormat(N10X.Editor.GetCurrentFilename())
+
+
+#------------------------------------------------------------------------
+def ClangFormatPostSave(file):
+    if N10X.Editor.GetSetting("ClangFormat.OnSave") != "true":
+        return
+
+    EXTS = [
+        ".c", ".cc", ".cpp", ".c++", ".cp", ".cxx",
+        ".h", ".hh", ".hpp", ".h++",".hp",".hxx",
+        ".inl",".ixx"
+    ]
+    extensions = N10X.Editor.GetSetting("ClangFormat.OnSaveExtensions")
+    if not extensions:
+        extensions = EXTS
+    else:
+        extensions = [e.strip() for e in extensions.split(",")]
+
+    if any(file.endswith(ext) for ext in extensions):
+        _ClangFormat(file)
+
+
+N10X.Editor.AddPostFileSaveFunction(ClangFormatPostSave)

--- a/PythonScripts/ClangFormat/ClangFormat.py
+++ b/PythonScripts/ClangFormat/ClangFormat.py
@@ -67,5 +67,5 @@ def ClangFormatFile():
                             close_fds=True, cwd=cwd)
         process.communicate()
     except FileNotFoundError:
-         print('[ClangFormat]: clang-format executable "' + settings.bin_path + '" could not be found')
+        print('[ClangFormat]: clang-format executable "' + settings.bin_path + '" could not be found')
     N10X.Editor.CheckForModifiedFiles()

--- a/PythonScripts/ClangFormat/ClangFormat.py
+++ b/PythonScripts/ClangFormat/ClangFormat.py
@@ -1,7 +1,7 @@
 # clang-format plugin for 10x
 # Settings:
 #     - "ClangFormat.Path": Path to clang-format executable, default: "clang-format.exe"
-#     - "ClangFormat.Stlye": One of 'LLVM', 'GNU', 'Google', 'Chromium', 'Microsoft', 'Mozilla', 'WebKit' values
+#     - "ClangFormat.Style": One of 'LLVM', 'GNU', 'Google', 'Chromium', 'Microsoft', 'Mozilla', 'WebKit' values
 #                            Or 'file' if you are providing .clang-format file in your project
 #
 import subprocess
@@ -43,11 +43,11 @@ def ClangFormatSelection():
                                         '--lines=' + str(start[1]) + ':' + str(end[1]),
                                         '-i',
                                         N10X.Editor.GetCurrentFilename()],
-                            shell=True, stdin=None, stdout=None, stderr=None, 
+                            shell=True, stdin=None, stdout=None, stderr=None,
                             close_fds=True, cwd=cwd)
             process.communicate()
         except FileNotFoundError:
-            print('[ClangFormat]: clang-format executable "' + settings.bin_path + '" could not be found')    
+            print('[ClangFormat]: clang-format executable "' + settings.bin_path + '" could not be found')
         N10X.Editor.CheckForModifiedFiles()
 
 #------------------------------------------------------------------------
@@ -63,10 +63,9 @@ def ClangFormatFile():
                                     '-style=' + settings.style_name,
                                     '-i',
                                     N10X.Editor.GetCurrentFilename()],
-                            shell=True, stdin=None, stdout=None, stderr=None, 
+                            shell=True, stdin=None, stdout=None, stderr=None,
                             close_fds=True, cwd=cwd)
         process.communicate()
     except FileNotFoundError:
          print('[ClangFormat]: clang-format executable "' + settings.bin_path + '" could not be found')
     N10X.Editor.CheckForModifiedFiles()
-

--- a/PythonScripts/ClangFormat/ClangFormat.py
+++ b/PythonScripts/ClangFormat/ClangFormat.py
@@ -27,44 +27,44 @@ def _ClangFormatReadSettings():
 
     return ClangFormatConfig(bin_path, style_name)
 
-def ClangFormatSelection():
-    start = N10X.Editor.GetSelectionStart()[1]
-    end = N10X.Editor.GetSelectionEnd()[1]
-    if start != end:
-        settings = _ClangFormatReadSettings()
-        N10X.Editor.SaveFile()
-        cwd = None
-        if settings.style_name == 'file':
-            cwd = os.path.dirname(settings.bin_path)
-        try:
-            process = subprocess.Popen([settings.bin_path,
-                                        '--style=' + settings.style_name,
-                                        '--lines=' + str(start) + ':' + str(end),
-                                        '-i',
-                                        N10X.Editor.GetCurrentFilename()],
-                            shell=True, stdin=None, stdout=None, stderr=None,
-                            close_fds=True, cwd=cwd)
-            process.communicate()
-        except FileNotFoundError:
-            print('[ClangFormat]: clang-format executable "' + settings.bin_path + '" could not be found')
-        N10X.Editor.CheckForModifiedFiles()
 
-#------------------------------------------------------------------------
-def ClangFormatFile():
+def _ClangFormat(file, line_range=None):
     settings = _ClangFormatReadSettings()
 
-    N10X.Editor.SaveFile()
     try:
         cwd = None
         if settings.style_name == 'file':
             cwd = os.path.dirname(settings.bin_path)
-        process = subprocess.Popen([settings.bin_path,
-                                    '-style=' + settings.style_name,
-                                    '-i',
-                                    N10X.Editor.GetCurrentFilename()],
+
+        command = [settings.bin_path,
+                   '--style=' + settings.style_name,
+                   '-i']
+
+        if line_range is not None:
+            start = line_range[0]
+            end = line_range[1]
+            if start != end:
+                command.append('--lines=' + str(start) + ':' + str(end))
+
+        command.append(file)
+
+        process = subprocess.Popen(command,
                             shell=True, stdin=None, stdout=None, stderr=None,
                             close_fds=True, cwd=cwd)
         process.communicate()
     except FileNotFoundError:
         print('[ClangFormat]: clang-format executable "' + settings.bin_path + '" could not be found')
-    N10X.Editor.CheckForModifiedFiles()
+
+
+def ClangFormatSelection():
+    start = N10X.Editor.GetSelectionStart()[1]
+    end = N10X.Editor.GetSelectionEnd()[1]
+    if start != end:
+        N10X.Editor.SaveFile()
+        _ClangFormat(N10X.Editor.GetCurrentFilename(), (start, end))
+
+
+#------------------------------------------------------------------------
+def ClangFormatFile():
+    N10X.Editor.SaveFile()
+    _ClangFormat(N10X.Editor.GetCurrentFilename())

--- a/PythonScripts/ClangFormat/ClangFormat.py
+++ b/PythonScripts/ClangFormat/ClangFormat.py
@@ -49,9 +49,13 @@ def _ClangFormat(file, line_range=None):
         command.append(file)
 
         process = subprocess.Popen(command,
-                            shell=True, stdin=None, stdout=None, stderr=None,
+                            shell=True, stdin=None, stdout=None, stderr=subprocess.PIPE,
                             close_fds=True, cwd=cwd)
-        process.communicate()
+        _, stderr = process.communicate()
+        if process.returncode != 0:
+            print('[ClangFormat]: clang-format failed (exit code ' + str(process.returncode) + ')')
+            if stderr:
+                print('[ClangFormat]: ' + stderr.decode(errors='replace'))
     except FileNotFoundError:
         print('[ClangFormat]: clang-format executable "' + settings.bin_path + '" could not be found')
 

--- a/PythonScripts/ClangFormat/ClangFormat.py
+++ b/PythonScripts/ClangFormat/ClangFormat.py
@@ -51,7 +51,7 @@ def _ClangFormat(file, line_range=None):
         command.append(file)
 
         process = subprocess.Popen(command,
-                            shell=True, stdin=None, stdout=None, stderr=subprocess.PIPE,
+                            shell=False, stdin=None, stdout=None, stderr=subprocess.PIPE,
                             close_fds=True, cwd=cwd,
                             creationflags=subprocess.CREATE_NO_WINDOW)
         _, stderr = process.communicate()

--- a/PythonScripts/ClangFormat/ClangFormat.py
+++ b/PythonScripts/ClangFormat/ClangFormat.py
@@ -28,11 +28,10 @@ def _ClangFormatReadSettings():
     return ClangFormatConfig(bin_path, style_name)
 
 def ClangFormatSelection():
-    settings = _ClangFormatReadSettings()
-
     start = N10X.Editor.GetSelectionStart()
     end = N10X.Editor.GetSelectionEnd()
     if start[1] != end[1]:
+        settings = _ClangFormatReadSettings()
         N10X.Editor.SaveFile()
         cwd = None
         if settings.style_name == 'file':

--- a/PythonScripts/ClangFormat/ClangFormat.py
+++ b/PythonScripts/ClangFormat/ClangFormat.py
@@ -34,7 +34,7 @@ def _ClangFormat(file, line_range=None):
     try:
         cwd = None
         if settings.style_name == 'file':
-            cwd = os.path.dirname(settings.bin_path)
+            cwd = os.path.dirname(file) or None
 
         command = [settings.bin_path,
                    '--style=' + settings.style_name,

--- a/PythonScripts/ClangFormat/ClangFormat.py
+++ b/PythonScripts/ClangFormat/ClangFormat.py
@@ -28,9 +28,9 @@ def _ClangFormatReadSettings():
     return ClangFormatConfig(bin_path, style_name)
 
 def ClangFormatSelection():
-    start = N10X.Editor.GetSelectionStart()
-    end = N10X.Editor.GetSelectionEnd()
-    if start[1] != end[1]:
+    start = N10X.Editor.GetSelectionStart()[1]
+    end = N10X.Editor.GetSelectionEnd()[1]
+    if start != end:
         settings = _ClangFormatReadSettings()
         N10X.Editor.SaveFile()
         cwd = None
@@ -39,7 +39,7 @@ def ClangFormatSelection():
         try:
             process = subprocess.Popen([settings.bin_path,
                                         '--style=' + settings.style_name,
-                                        '--lines=' + str(start[1]) + ':' + str(end[1]),
+                                        '--lines=' + str(start) + ':' + str(end),
                                         '-i',
                                         N10X.Editor.GetCurrentFilename()],
                             shell=True, stdin=None, stdout=None, stderr=None,

--- a/PythonScripts/ClangFormat/README.md
+++ b/PythonScripts/ClangFormat/README.md
@@ -2,4 +2,6 @@
 
 ### Settings
 - **ClangFormat.Path**: Path to clang-format executable, default: "clang-format.exe"
-- **ClangFormat.Stlye**: One of 'LLVM', 'GNU', 'Google', 'Chromium', 'Microsoft', 'Mozilla', 'WebKit' values, Or 'file' if you are providing .clang-format file in your project
+- **ClangFormat.Style**: One of 'LLVM', 'GNU', 'Google', 'Chromium', 'Microsoft', 'Mozilla', 'WebKit' values, or 'file' if you are providing a .clang-format file in your project
+- **ClangFormat.OnSave**: 'true' or 'false'. When true, clang-format is called on every file save
+- **ClangFormat.OnSaveExtensions**: Comma-separated list of file extensions to auto-format on save. Defaults to C and C++ source and header extensions


### PR DESCRIPTION
We add the ability to configure the ClangFormat script so that it auto-formats on save. 

We also make a couple more improvements:
- go back to shell=False, which appears faster
- capture stderr and shows it on error
