### PR TITLE
Update regex for variable highlighting in cs.10x_syntax

### DIFF
--- a/SyntaxHighlighting/cs.10x_syntax
+++ b/SyntaxHighlighting/cs.10x_syntax
@@ -235,5 +235,5 @@ REGEX(([a-zA-Z_]+\w*)\s+(?:[a-zA-Z_]+\w*)\s*(?:=|\:|in))
 REGEX(([a-zA-Z_]+\w*)<.*?>)
 
 Language.Variable:
-REGEX(\b[a-zA-Z_]+\w*\b)
+REGEX((?<![a-zA-ZÀ-ÿ0-9_])[a-zA-ZÀ-ÿ_][a-zA-ZÀ-ÿ0-9_]*(?![a-zA-ZÀ-ÿ0-9_]))
 


### PR DESCRIPTION
Update to fix a minor issue with the color of the glyph when typing accented characters (EX: `êíã`) .
<img width="258" height="76" alt="image" src="https://github.com/user-attachments/assets/6a477917-56d3-43d1-9d04-27eaa3ef31e9" />
